### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/projects/ngx-translate/src/lib/util.ts
+++ b/projects/ngx-translate/src/lib/util.ts
@@ -147,6 +147,11 @@ export function setValue(target: any, key: string, value: any): void {
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
 
+    // Skip dangerous properties to prevent prototype pollution
+    if (key === '__proto__' || key === 'constructor') {
+      continue;
+    }
+
     // If we're at the last key, set the value
     if (i === keys.length - 1) {
       current[key] = value;


### PR DESCRIPTION
Fixes [https://github.com/CodeAndWeb/ngx-translate/security/code-scanning/2](https://github.com/CodeAndWeb/ngx-translate/security/code-scanning/2)

To fix the prototype pollution vulnerability, we need to ensure that the `setValue` function does not allow setting properties on the `Object.prototype`. This can be achieved by blocking the `__proto__` and `constructor` properties from being assigned.

- Modify the `setValue` function to include checks that skip the assignment if the key is `__proto__` or `constructor`.
- This change will be made in the file `projects/ngx-translate/src/lib/util.ts` around the lines where the `current` object is being assigned properties.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
